### PR TITLE
change printf to exec basename

### DIFF
--- a/app/src/main/java/xyz/chz/bfm/util/command/TermCmd.kt
+++ b/app/src/main/java/xyz/chz/bfm/util/command/TermCmd.kt
@@ -125,7 +125,7 @@ object TermCmd {
 
     private fun getNameConfig(what: String, isClash: Boolean): String {
         val m = if (isClash) "yaml" else "json"
-        return execRootCmd("find ${path}/$what/ -maxdepth 1 -name 'config.$m' -type f -printf '%f\n'")
+        return execRootCmd("find ${path}/$what/ -maxdepth 1 -name 'config.$m' -type f -exec basename {} \\;")
     }
 
 


### PR DESCRIPTION
some device doesnt have `find` with `-printf` feature, also magisk busybox aplet `find` doesnt have `-printf`  feature.

example : 
```
find /data/adb/box/clash/ -maxdepth 1 -name 'config.yaml' -type f -printf '%f\n'                                       <
find: bad arg '-printf'
```